### PR TITLE
Add Code Editor and Visualizer links to header

### DIFF
--- a/client/src/components/Header.jsx
+++ b/client/src/components/Header.jsx
@@ -8,7 +8,7 @@ import {
   AiOutlineFileAdd,
   AiOutlineLogout,
 } from 'react-icons/ai';
-import { FaMoon, FaSun, FaHome, FaInfoCircle, FaCode } from 'react-icons/fa';
+import { FaMoon, FaSun, FaHome, FaInfoCircle, FaCode, FaLaptopCode, FaChartLine } from 'react-icons/fa';
 import { HiOutlineExclamationCircle } from 'react-icons/hi';
 import { useSelector, useDispatch } from 'react-redux';
 import { motion, AnimatePresence, useScroll, useMotionValueEvent } from 'framer-motion';
@@ -235,6 +235,8 @@ export default function Header() {
     { label: 'Home', path: '/', icon: <FaHome /> },
     { label: 'About', path: '/about', icon: <FaInfoCircle /> },
     { label: 'Projects', path: '/projects', icon: <FaCode /> },
+    { label: 'Code Editor', path: '/tryit', icon: <FaLaptopCode /> },
+    { label: 'Code Visualizer', path: '/visualizer', icon: <FaChartLine /> },
   ];
 
   const handleMouseMove = (e) => {


### PR DESCRIPTION
## Summary
- add Code Editor and Code Visualizer navigation links with icons to header

## Testing
- `npm test` *(fails: Jest encountered an unexpected token and missing jsdom environment)*

------
https://chatgpt.com/codex/tasks/task_b_68bc1ee2a62083248b776fb14268f68e