### PR TITLE
fix(post): validate post ownership

### DIFF
--- a/api/controllers/post.controller.js
+++ b/api/controllers/post.controller.js
@@ -88,10 +88,16 @@ export const getposts = async (req, res, next) => {
 };
 
 export const deletepost = async (req, res, next) => {
-  if (!req.user.isAdmin && req.user.id !== req.params.userId) {
-    return next(errorHandler(403, 'You are not allowed to delete this post'));
-  }
   try {
+    const post = await Post.findById(req.params.postId);
+    if (!post) {
+      return next(errorHandler(404, 'Post not found'));
+    }
+
+    if (!req.user.isAdmin && post.userId !== req.user.id) {
+      return next(errorHandler(403, 'You are not allowed to delete this post'));
+    }
+
     await Post.findByIdAndDelete(req.params.postId);
     res.status(200).json('The post has been deleted');
   } catch (error) {
@@ -100,10 +106,16 @@ export const deletepost = async (req, res, next) => {
 };
 
 export const updatepost = async (req, res, next) => {
-  if (!req.user.isAdmin && req.user.id !== req.params.userId) {
-    return next(errorHandler(403, 'You are not allowed to update this post'));
-  }
   try {
+    const post = await Post.findById(req.params.postId);
+    if (!post) {
+      return next(errorHandler(404, 'Post not found'));
+    }
+
+    if (!req.user.isAdmin && post.userId !== req.user.id) {
+      return next(errorHandler(403, 'You are not allowed to update this post'));
+    }
+
     const slug = req.body.title ? generateSlug(req.body.title) : undefined;
 
     const updatedPost = await Post.findByIdAndUpdate(

--- a/api/routes/post.route.js
+++ b/api/routes/post.route.js
@@ -14,8 +14,8 @@ const router = express.Router();
 
 router.post('/create', verifyToken, create);
 router.get('/getposts', getposts);
-router.delete('/deletepost/:postId/:userId', verifyToken, deletepost);
-router.put('/updatepost/:postId/:userId', verifyToken, updatepost);
+router.delete('/deletepost/:postId', verifyToken, deletepost);
+router.put('/updatepost/:postId', verifyToken, updatepost);
 
 // --- NEW --- This is the new route for handling claps.
 // It uses a PUT method because a clap "updates" the post's clap count.


### PR DESCRIPTION
## Summary
- ensure only owners or admins can update or delete posts
- remove userId path parameter from post routes to prevent tampering

## Testing
- `npm test` *(fails: Test environment jest-environment-jsdom cannot be found; SyntaxError: Cannot use import statement outside a module)*

------
https://chatgpt.com/codex/tasks/task_b_68be32852e7c832da93ac1f3bee1c4c2