### PR TITLE
feat: add basic routing

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1,10 +1,15 @@
 import AppShell from './components/layout/AppShell.jsx';
+import { Routes, Route } from 'react-router-dom';
+import Home from './pages/Home.jsx';
 import Dashboard from './pages/Dashboard.jsx';
 
 export default function App() {
   return (
     <AppShell>
-      <Dashboard />
+      <Routes>
+        <Route path="/" element={<Home />} />
+        <Route path="/dashboard" element={<Dashboard />} />
+      </Routes>
     </AppShell>
   );
 }

--- a/client/src/main.jsx
+++ b/client/src/main.jsx
@@ -3,11 +3,14 @@ import ReactDOM from 'react-dom/client';
 import App from './App.jsx';
 import './index.css';
 import { ThemeProvider } from './theme/ThemeProvider.jsx';
+import { BrowserRouter } from 'react-router-dom';
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
     <ThemeProvider>
-      <App />
+      <BrowserRouter>
+        <App />
+      </BrowserRouter>
     </ThemeProvider>
   </React.StrictMode>
 );


### PR DESCRIPTION
## Summary
- wrap App with BrowserRouter
- define routes for Home and Dashboard

## Testing
- `npm test`
- `npm run lint --prefix client` *(fails: 391 errors, 16 warnings)*
- `npm run dev -- --host 0.0.0.0`
- `curl http://localhost:5173/`

------
https://chatgpt.com/codex/tasks/task_b_68bf8d1042ac832dbe462726466ebbde