### PR TITLE
fix: add QueryClientProvider for React Query

### DIFF
--- a/client/src/main.jsx
+++ b/client/src/main.jsx
@@ -7,16 +7,21 @@ import { BrowserRouter } from 'react-router-dom';
 import { Provider } from 'react-redux';
 import { PersistGate } from 'redux-persist/integration/react';
 import { store, persistor } from './redux/store.js';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+const queryClient = new QueryClient();
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
     <Provider store={store}>
       <PersistGate loading={null} persistor={persistor}>
-        <ThemeProvider>
-          <BrowserRouter>
-            <App />
-          </BrowserRouter>
-        </ThemeProvider>
+        <QueryClientProvider client={queryClient}>
+          <ThemeProvider>
+            <BrowserRouter>
+              <App />
+            </BrowserRouter>
+          </ThemeProvider>
+        </QueryClientProvider>
       </PersistGate>
     </Provider>
   </React.StrictMode>


### PR DESCRIPTION
## Summary
- wrap root render in `QueryClientProvider`
- initialize `QueryClient`

## Testing
- `npm test`
- `npm run lint --prefix client` *(fails: 407 problems (391 errors, 16 warnings))*

------
https://chatgpt.com/codex/tasks/task_b_68bf9129436c832db989daeb43008b86