### PR TITLE
feat: add comprehensive routing

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1,15 +1,60 @@
-import AppShell from './components/layout/AppShell.jsx';
+import { Suspense, lazy } from 'react';
 import { Routes, Route } from 'react-router-dom';
-import Home from './pages/Home.jsx';
-import Dashboard from './pages/Dashboard.jsx';
+import AppShell from './components/layout/AppShell.jsx';
+
+// Lazy-loaded page components
+const Home = lazy(() => import('./pages/Home.jsx'));
+const Dashboard = lazy(() => import('./pages/Dashboard.jsx'));
+const About = lazy(() => import('./pages/About.jsx'));
+const Projects = lazy(() => import('./pages/Projects.jsx'));
+const Tutorials = lazy(() => import('./pages/Tutorials.jsx'));
+const SingleTutorialPage = lazy(() => import('./pages/SingleTutorialPage.jsx'));
+const CreateTutorial = lazy(() => import('./pages/CreateTutorial.jsx'));
+const UpdateTutorial = lazy(() => import('./pages/UpdateTutorial.jsx'));
+const Quizzes = lazy(() => import('./pages/Quizzes.jsx'));
+const SingleQuizPage = lazy(() => import('./pages/SingleQuizPage.jsx'));
+const CreateQuiz = lazy(() => import('./pages/CreateQuiz.jsx'));
+const UpdateQuiz = lazy(() => import('./pages/UpdateQuiz.jsx'));
+const CreatePost = lazy(() => import('./pages/CreatePost.jsx'));
+const UpdatePost = lazy(() => import('./pages/UpdatePost.jsx'));
+const PostPage = lazy(() => import('./pages/PostPage.jsx'));
+const PostListPage = lazy(() => import('./pages/PostListPage.jsx'));
+const Search = lazy(() => import('./pages/Search.jsx'));
+const SignIn = lazy(() => import('./pages/SignIn.jsx'));
+const SignUp = lazy(() => import('./pages/SignUp.jsx'));
+const TryItPage = lazy(() => import('./pages/TryItPage.jsx'));
+const CodeVisualizer = lazy(() => import('./pages/CodeVisualizer.jsx'));
+const NotFound = lazy(() => import('./pages/NotFound.jsx'));
 
 export default function App() {
   return (
     <AppShell>
-      <Routes>
-        <Route path="/" element={<Home />} />
-        <Route path="/dashboard" element={<Dashboard />} />
-      </Routes>
+      <Suspense fallback={<div className="p-4">Loading...</div>}>
+        <Routes>
+          <Route path="/" element={<Home />} />
+          <Route path="/dashboard" element={<Dashboard />} />
+          <Route path="/about" element={<About />} />
+          <Route path="/projects" element={<Projects />} />
+          <Route path="/search" element={<Search />} />
+          <Route path="/sign-in" element={<SignIn />} />
+          <Route path="/sign-up" element={<SignUp />} />
+          <Route path="/posts" element={<PostListPage />} />
+          <Route path="/post/:postSlug" element={<PostPage />} />
+          <Route path="/create-post" element={<CreatePost />} />
+          <Route path="/update-post/:postId" element={<UpdatePost />} />
+          <Route path="/tutorials" element={<Tutorials />} />
+          <Route path="/tutorials/:tutorialSlug/:chapterSlug?" element={<SingleTutorialPage />} />
+          <Route path="/create-tutorial" element={<CreateTutorial />} />
+          <Route path="/update-tutorial/:tutorialId" element={<UpdateTutorial />} />
+          <Route path="/quizzes" element={<Quizzes />} />
+          <Route path="/quizzes/:quizSlug" element={<SingleQuizPage />} />
+          <Route path="/create-quiz" element={<CreateQuiz />} />
+          <Route path="/update-quiz/:quizId" element={<UpdateQuiz />} />
+          <Route path="/tryit" element={<TryItPage />} />
+          <Route path="/visualizer" element={<CodeVisualizer />} />
+          <Route path="*" element={<NotFound />} />
+        </Routes>
+      </Suspense>
     </AppShell>
   );
 }


### PR DESCRIPTION
## Summary
- add lazy-loaded imports for all app pages
- configure full set of routes including tutorials, quizzes, posts, tools, and auth

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: ESLint couldn't find a configuration file)


------
https://chatgpt.com/codex/tasks/task_b_68bf98325a84832dbacceb6a91e751bb