### PR TITLE
Refactor route protection with nested private routes

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1,6 +1,8 @@
 import { Suspense, lazy } from 'react';
-import { Routes, Route } from 'react-router-dom';
+import { Routes, Route, Outlet } from 'react-router-dom';
 import AppShell from './components/layout/AppShell.jsx';
+import PrivateRoute from './components/PrivateRoute.jsx';
+import OnlyAdminPrivateRoute from './components/OnlyAdminPrivateRoute.jsx';
 
 // Lazy-loaded page components
 const Home = lazy(() => import('./pages/Home.jsx'));
@@ -32,7 +34,6 @@ export default function App() {
       <Suspense fallback={<div className="p-4">Loading...</div>}>
         <Routes>
           <Route path="/" element={<Home />} />
-          <Route path="/dashboard" element={<Dashboard />} />
           <Route path="/about" element={<About />} />
           <Route path="/projects" element={<Projects />} />
           <Route path="/search" element={<Search />} />
@@ -40,18 +41,25 @@ export default function App() {
           <Route path="/sign-up" element={<SignUp />} />
           <Route path="/posts" element={<PostListPage />} />
           <Route path="/post/:postSlug" element={<PostPage />} />
-          <Route path="/create-post" element={<CreatePost />} />
-          <Route path="/update-post/:postId" element={<UpdatePost />} />
           <Route path="/tutorials" element={<Tutorials />} />
           <Route path="/tutorials/:tutorialSlug/:chapterSlug?" element={<SingleTutorialPage />} />
-          <Route path="/create-tutorial" element={<CreateTutorial />} />
-          <Route path="/update-tutorial/:tutorialId" element={<UpdateTutorial />} />
           <Route path="/quizzes" element={<Quizzes />} />
           <Route path="/quizzes/:quizSlug" element={<SingleQuizPage />} />
-          <Route path="/create-quiz" element={<CreateQuiz />} />
-          <Route path="/update-quiz/:quizId" element={<UpdateQuiz />} />
           <Route path="/tryit" element={<TryItPage />} />
           <Route path="/visualizer" element={<CodeVisualizer />} />
+
+          <Route element={<PrivateRoute />}>
+            <Route path="/dashboard" element={<Dashboard />} />
+            <Route element={<OnlyAdminPrivateRoute />}>
+              <Route path="/create-post" element={<CreatePost />} />
+              <Route path="/update-post/:postId" element={<UpdatePost />} />
+              <Route path="/create-tutorial" element={<CreateTutorial />} />
+              <Route path="/update-tutorial/:tutorialId" element={<UpdateTutorial />} />
+              <Route path="/create-quiz" element={<CreateQuiz />} />
+              <Route path="/update-quiz/:quizId" element={<UpdateQuiz />} />
+            </Route>
+          </Route>
+
           <Route path="*" element={<NotFound />} />
         </Routes>
       </Suspense>


### PR DESCRIPTION
## Summary
- import Outlet and route guard components
- nest authenticated routes under PrivateRoute
- nest admin-only routes under OnlyAdminPrivateRoute

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68bf9b690254832dab3db18b0b39c20f